### PR TITLE
Add juneteeth as observed holiday

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+env:
+  MIX_ENV: test
+
 jobs:
   build:
 
@@ -26,6 +29,10 @@ jobs:
         key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
         restore-keys: ${{ runner.os }}-mix-
     - name: Install dependencies
-      run: MIX_ENV=test mix deps.get
+      run: |
+        mix local.rebar --force
+        mix local.hex --force
+        mix deps.get
+        mix deps.compile
     - name: Run tests
-      run: MIX_ENV=test mix test --color
+      run: mix test --color

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.3.3
+
+### Changed
+
+- Fix issue #27 : Incorrect observed date if Christmas falls on saturday
+  
 ## 0.3.2
 
 ### Added

--- a/lib/holidefs.ex
+++ b/lib/holidefs.ex
@@ -186,7 +186,7 @@ defmodule Holidefs do
          opts
        ) do
     holidays =
-      start.year..finish.year
+      start.year..(finish.year + 1)
       |> Stream.flat_map(&all_year_holidays(definition, &1, opts))
       |> Stream.drop_while(&(Date.compare(&1.date, start) == :lt))
       |> Enum.take_while(&(Date.compare(&1.date, finish) != :gt))

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Holidefs.Mixfile do
   def project do
     [
       app: :holidefs,
-      version: "0.3.2",
+      version: "0.3.3",
       elixir: "~> 1.5",
       description: "Definition-based national holidays",
       source_url: @github_url,

--- a/priv/calendars/definitions/us.yaml
+++ b/priv/calendars/definitions/us.yaml
@@ -65,6 +65,7 @@
 # - http://www.kleiner-kalender.de/event/rosch-ha-schana/0651c.html
 # - http://www.kaldix.com/united-states/calendar/virginia/holidays/independence-day/year-2017/
 # - https://publicholidays.us/independence-day/
+# - https://www.ca2.uscourts.gov/clerk/calendars/federal_holidays.html
 ---
 months:
   0:
@@ -935,7 +936,7 @@ tests:
     expect:
       holiday: false
   - given:
-      date: ['2021-12-27', '2022-12-26', '2027-12-27']
+      date: ['2021-12-24', '2022-12-26', '2027-12-24']
       regions: ["us"]
       options: ["observed"]
     expect:

--- a/priv/calendars/definitions/us.yaml
+++ b/priv/calendars/definitions/us.yaml
@@ -210,6 +210,7 @@ months:
   - name: Independence Day # fixed
     regions: [us]
     mday: 4
+    observed: to_weekday_if_weekend(date)
   - name: Independence Day (Holiday)
     regions: [us_va]
     mday: 4
@@ -730,8 +731,9 @@ tests:
   - given:
       date: ['2020-7-3', '2021-7-5', '2026-7-3']
       regions: ["us"]
+      options: ["observed"]
     expect:
-      holiday: false
+      name: "Independence Day"
   - given:
       date: ['2020-7-3', '2021-7-5', '2026-7-3']
       regions: ["us_va"]

--- a/priv/calendars/definitions/us.yaml
+++ b/priv/calendars/definitions/us.yaml
@@ -200,6 +200,7 @@ months:
   - name: Emancipation Day in Texas # fixed
     regions: [us_tx]
     mday: 19
+    observed: to_weekday_if_weekend(date)
   - name: West Virginia Day
     regions: [us_wv]
     mday: 20

--- a/priv/calendars/definitions/us.yaml
+++ b/priv/calendars/definitions/us.yaml
@@ -303,7 +303,7 @@ months:
   - name: Christmas Day
     regions: [us]
     mday: 25
-    observed: to_monday_if_weekend(date)
+    observed: to_weekday_if_weekend(date)
   - name: Day after Christmas
     regions: [us_ar, us_nc, us_ok, us_sc, us_tn, us_tx]
     mday: 26


### PR DESCRIPTION
Juneteeth is an observed federal holiday, we need to add it to the list of holidefs holidays in the US so clearinghouse can perform correct date calculations

https://www.federalreserve.gov/aboutthefed/k8.htm