### PR TITLE
Add missing 2023 UK bank holiday

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -11,28 +11,40 @@ env:
 
 jobs:
   build:
-
     name: Build and test
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Elixir
-      uses: erlef/setup-elixir@885971a72ed1f9240973bd92ab57af8c1aa68f24
+
+    - uses: cachix/install-nix-action@v19
       with:
-        elixir-version: '1.11.4' # Define the elixir version [required]
-        otp-version: '22.3' # Define the OTP version [required]
-    - name: Restore dependencies cache
-      uses: actions/cache@v2
+        github_access_token: ${{ secrets.GITHUB_TOKEN }}
+        extra_nix_config: |
+          # NOTE: Reassign the nix store to this to avoid permission issues when
+          #trying to restoring what was cached by GitHub Actions.
+          store = /home/runner/nix
+
+          # NOTE: Other binary caches for us to use if cache.nixos.org doesn't
+          # have what we need.
+          trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+          substituters = https://cache.iog.io https://cache.nixos.org/
+
+    - name: Restore cached nix store
+      uses: actions/cache@v3
+      with:
+        path: /home/runner/nix
+        key: ${{ runner.os }}-nix-${{ hashFiles('flake.lock') }}
+
+    - name: Restore cached mix deps
+      uses: actions/cache@v3
       with:
         path: deps
         key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
         restore-keys: ${{ runner.os }}-mix-
+
     - name: Install dependencies
-      run: |
-        mix local.rebar --force
-        mix local.hex --force
-        mix deps.get
-        mix deps.compile
+      run: nix develop .#devShells.x86_64-linux.ci --command bash -c "mix local.rebar --force && mix local.hex --force && mix deps.get && mix deps.compile"
+
     - name: Run tests
-      run: mix test --color
+      run: nix develop .#devShells.x86_64-linux.ci --command mix test --color

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+### Elixir/Erlang ###
 # The directory Mix will write compiled artifacts to.
 /_build/
 
@@ -24,3 +25,7 @@ erl_crash.dump
 *.ez
 
 .DS_Store
+
+### nix ###
+.direnv
+result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,26 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1682313135,
+        "narHash": "sha256-pP93z4DQ5p0LM6NLUCVmAeNdr7r4nHuTmwPzskMY2RA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b03ac42b0734da3e7be9bf8d94433a5195734b19",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,31 @@
+{
+  description = "Holidefs: Definition-based national holidays in Elixir";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs";
+
+  outputs = { self, nixpkgs }:
+    let
+      elixirOverlay = final: prev: {
+        elixir-ls = (prev.elixir-ls.override {
+          elixir = prev.beam.packages.erlangR24.elixir_1_12;
+        });
+      };
+
+      system = "x86_64-linux";
+      pkgs = import nixpkgs { inherit system; overlays = [ elixirOverlay ]; };
+    in {
+      devShells.${system} = {
+        default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            nil
+            beam.packages.erlangR24.elixir_1_12
+            elixir_ls
+          ];
+        };
+
+        ci = pkgs.mkShell {
+          buildInputs = with pkgs; [ beam.packages.erlangR24.elixir_1_12 ];
+        };
+      };
+    };
+}

--- a/priv/calendars/definitions/gb.yaml
+++ b/priv/calendars/definitions/gb.yaml
@@ -53,6 +53,11 @@ months:
     regions: [gb]
     week: -1
     wday: 1
+  - name: Bank Holiday for the Coronation of King Charles III
+    regions: [gb]
+    mday: 8
+    year_ranges:
+      - limited: [2023]
   7:
   - name: Tynwald Day
     regions: [im, gb_iom]
@@ -372,3 +377,18 @@ tests:
       regions: ["je"]
     expect:
       name: "Bank Holiday"
+  - given:
+      date: '2023-05-08'
+      regions: ["gb"]
+    expect:
+      name: "Bank Holiday for the Coronation of King Charles III"
+  - given:
+      date: '2024-05-08'
+      regions: ['gb']
+    expect:
+      holiday: false
+  - given:
+      date: '2022-05-08'
+      regions: ['gb']
+    expect:
+      holiday: false


### PR DESCRIPTION
Adds the bank holiday for the coronation of King Charles III. This also fixes the CI that broke last Feb 2023.

https://www.gov.uk/bank-holidays#england-and-wales